### PR TITLE
feat: 파서 출력 가독성 개선 및 rich 의존성 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
-dependencies = []
+dependencies = [
+    "rich>=14.3.3",
+]
 
 [dependency-groups]
 dev = [

--- a/src/fetch/school_schedule.py
+++ b/src/fetch/school_schedule.py
@@ -41,4 +41,5 @@ def main():
 
 
 if __name__ == "__main__":
+    # uv run python -m src.fetch.school_schedule
     main()

--- a/src/parse/schedule_parser.py
+++ b/src/parse/schedule_parser.py
@@ -4,6 +4,7 @@ from html import unescape
 from pathlib import Path
 
 import requests
+from rich import print as rprint
 
 def parse_schedule(html: str):
     sys_id_match = re.search(r'<input[^>]*id="sysId"[^>]*value="([^"]*)"', html)
@@ -64,8 +65,9 @@ def parse_schedule(html: str):
 
 
 if __name__ == "__main__":
+    # uv run python -m src.parse.schedule_parser
     html_path = Path(__file__).resolve().parents[1] / "fetch" / "output" / "school_schedule.html"
     html = html_path.read_text(encoding="utf-8")
     schedules = parse_schedule(html)
-    print(len(schedules))
-    print(schedules[:])
+    rprint(len(schedules))
+    rprint(schedules[:])


### PR DESCRIPTION
## Summary
- `schedule_parser` 출력을 `rich` 기반으로 변경하여 결과 확인 가독성을 높였습니다.
- 파서/수집 모듈의 직접 실행 시 사용할 수 있는 실행 명령 주석을 추가했습니다.
- 프로젝트 의존성에 `rich`를 추가했습니다.

## Test plan
- [x] `uv run python -m src.parse.schedule_parser`
- [ ] fetch 모듈 실환경 호출 점검
- [ ] 회귀 영향 확인

Made with [Cursor](https://cursor.com)