### PR TITLE
streamlit_calendar 기반 월간 캘린더 UI 개선

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "rich>=14.3.3",
     "loguru>=0.7.3",
     "streamlit>=1.51.0",
+    "streamlit-calendar>=1.4.0",
 ]
 
 [dependency-groups]

--- a/src/ui/streamlit_app.py
+++ b/src/ui/streamlit_app.py
@@ -2,17 +2,16 @@ from __future__ import annotations
 
 import calendar
 import json
-from collections import defaultdict
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Iterable
 
 import streamlit as st
+from streamlit_calendar import calendar as streamlit_calendar
 
 
 DEFAULT_EVENTS_PATH = Path(__file__).resolve().parents[2] / "src" / "parse" / "output" / "merged_events.json"
-WEEKDAYS = ["월", "화", "수", "목", "금", "토", "일"]
 
 
 @dataclass(frozen=True)
@@ -82,54 +81,87 @@ def overlaps_month(event: ScheduleEvent, year: int, month: int) -> bool:
     return event.start_date <= month_end and event.end_date >= month_start
 
 
-def dates_in_month(event: ScheduleEvent, year: int, month: int) -> Iterable[date]:
-    _, last_day = calendar.monthrange(year, month)
-    current = max(event.start_date, date(year, month, 1))
-    end = min(event.end_date, date(year, month, last_day))
-
-    while current <= end:
-        yield current
-        current += timedelta(days=1)
-
-
-def events_by_day(events: Iterable[ScheduleEvent], year: int, month: int) -> dict[date, list[ScheduleEvent]]:
-    grouped: dict[date, list[ScheduleEvent]] = defaultdict(list)
-    for event in events:
-        for event_date in dates_in_month(event, year, month):
-            grouped[event_date].append(event)
-    return grouped
-
-
 def format_event_range(event: ScheduleEvent) -> str:
     if event.start_date == event.end_date:
         return event.start_date.isoformat()
     return f"{event.start_date.isoformat()} - {event.end_date.isoformat()}"
 
 
-def render_calendar(events: list[ScheduleEvent], year: int, month: int) -> None:
-    cal = calendar.Calendar(firstweekday=0)
-    grouped_events = events_by_day(events, year, month)
+def event_color(title: str) -> str:
+    if "방학" in title:
+        return "#2563eb"
+    if "휴업일" in title:
+        return "#64748b"
+    if any(keyword in title for keyword in ("설날", "신정", "공휴일")):
+        return "#dc2626"
+    return "#16a34a"
 
-    st.subheader(f"{year}년 {month}월")
-    header_columns = st.columns(7)
-    for column, weekday in zip(header_columns, WEEKDAYS, strict=True):
-        column.markdown(f"**{weekday}**")
 
-    for week in cal.monthdatescalendar(year, month):
-        columns = st.columns(7)
-        for column, current_date in zip(columns, week, strict=True):
-            in_month = current_date.month == month
-            day_events = grouped_events.get(current_date, [])
-            label = str(current_date.day) if in_month else f":gray[{current_date.day}]"
+def to_calendar_event(event: ScheduleEvent) -> dict[str, object]:
+    color = event_color(event.title)
+    return {
+        "title": event.title,
+        "start": event.start_date.isoformat(),
+        "end": (event.end_date + timedelta(days=1)).isoformat(),
+        "allDay": True,
+        "backgroundColor": color,
+        "borderColor": color,
+    }
 
-            with column:
-                with st.container(border=True):
-                    st.markdown(f"**{label}**")
-                    if in_month:
-                        for event in day_events[:3]:
-                            st.caption(event.title)
-                        if len(day_events) > 3:
-                            st.caption(f"외 {len(day_events) - 3}건")
+
+def calendar_options(year: int, month: int) -> dict[str, object]:
+    return {
+        "initialView": "dayGridMonth",
+        "initialDate": date(year, month, 1).isoformat(),
+        "locale": "ko",
+        "height": "auto",
+        "editable": False,
+        "selectable": False,
+        "headerToolbar": {
+            "left": "today prev,next",
+            "center": "title",
+            "right": "",
+        },
+        "buttonText": {
+            "today": "오늘",
+        },
+        "dayMaxEvents": True,
+    }
+
+
+def render_calendar(events: list[ScheduleEvent], year: int, month: int) -> dict | None:
+    st.subheader("월간 달력")
+    calendar_result = streamlit_calendar(
+        events=[to_calendar_event(event) for event in events],
+        options=calendar_options(year, month),
+        key=f"school-calendar-{year}-{month}",
+    )
+    return calendar_result if isinstance(calendar_result, dict) else None
+
+
+def month_from_calendar_result(calendar_result: dict | None, default_year: int, default_month: int) -> tuple[int, int]:
+    if not calendar_result:
+        return default_year, default_month
+
+    view = None
+    for value in calendar_result.values():
+        if isinstance(value, dict) and isinstance(value.get("view"), dict):
+            view = value["view"]
+            break
+
+    if not isinstance(view, dict):
+        return default_year, default_month
+
+    current_start = view.get("currentStart")
+    if not isinstance(current_start, str):
+        return default_year, default_month
+
+    try:
+        current_date = datetime.fromisoformat(current_start.replace("Z", "+00:00")).date()
+    except ValueError:
+        return default_year, default_month
+
+    return current_date.year, current_date.month
 
 
 def render_event_list(events: list[ScheduleEvent]) -> None:
@@ -165,14 +197,19 @@ def main() -> None:
         selected_year = st.selectbox("연도", years, index=years.index(default_year))
         selected_month = st.selectbox("월", list(range(1, 13)), index=default_month - 1)
 
+    calendar_result = render_calendar(events, selected_year, selected_month)
+    list_year, list_month = month_from_calendar_result(
+        calendar_result,
+        selected_year,
+        selected_month,
+    )
     month_events = [
         event
         for event in events
-        if overlaps_month(event, selected_year, selected_month)
+        if overlaps_month(event, list_year, list_month)
     ]
 
     st.metric("선택한 월 일정", len(month_events))
-    render_calendar(month_events, selected_year, selected_month)
     render_event_list(month_events)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1869,6 +1869,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "streamlit" },
+    { name = "streamlit-calendar" },
 ]
 
 [package.dev-dependencies]
@@ -1885,6 +1886,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "rich", specifier = ">=14.3.3" },
     { name = "streamlit", specifier = ">=1.51.0" },
+    { name = "streamlit-calendar", specifier = ">=1.4.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1994,6 +1996,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5d/f8/b2daf7a5f8ae15527daf94406e771bb6075e958a01c3dde9eba79dc3c9a3/streamlit-1.57.0.tar.gz", hash = "sha256:0b028d305c1a1a757071b2c9504966787602842fc8af6e873795ca58d2b4d12f", size = 8678859, upload-time = "2026-04-28T22:13:32.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/1a/3ca2293d8552bacea3e67e9600d2d1df7df4a325059769ad83d91c279595/streamlit-1.57.0-py3-none-any.whl", hash = "sha256:0d1d41972aeade5637dbb0e7f0eefa5312272f85304923d240a1b1f0475249c8", size = 9194216, upload-time = "2026-04-28T22:13:29.624Z" },
+]
+
+[[package]]
+name = "streamlit-calendar"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "streamlit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/da/d394612a18e8ee3410c088035a7b804e56c0318e0e9169a150158723910d/streamlit_calendar-1.4.0.tar.gz", hash = "sha256:47bd4fe839fdcbc7f334cb3aec0b83556558357562bb58c5a9fdfe11cd4e7b80", size = 1264452, upload-time = "2025-07-24T13:14:50.032Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/1b/76be5aa2aeacc34bf0022680e3e694bcdd6c812b93b122d617513ebdc9bc/streamlit_calendar-1.4.0-py3-none-any.whl", hash = "sha256:bba0fbd47c0910b8eb15fc3689d3f66a097bf26818da36a3c1737e00fe995966", size = 1276322, upload-time = "2025-07-24T13:14:48.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #8

## 요약

기존 `st.columns` 기반 수동 월간 달력 렌더링을 `streamlit_calendar` 기반 FullCalendar 렌더링으로 교체했습니다.

## 주요 변경 사항

- `streamlit-calendar>=1.4.0` 의존성 추가
- 병합 일정 데이터를 FullCalendar 이벤트 형식으로 변환
- 종일 일정의 종료일을 FullCalendar exclusive end 규칙에 맞춰 변환
- 키워드 기반 이벤트 색상 적용
- 캘린더 자체 today/prev/next 버튼 표시
- 기존 사이드바 연도/월 선택과 월간 일정 목록 유지

## 확인 방법

- `uv run python -m compileall src`
- `uv run python -c "from src.ui.streamlit_app import load_events, to_calendar_event; events, error = load_events(); assert error is None, error; item = to_calendar_event(events[1]); assert item['allDay'] is True; assert item['end'] == '2026-03-01'; print(len(events)); print(item['title']); print(item['end'])"`
- `bash scripts/run_streamlit.sh --server.headless true --server.port 18502`
- `curl -I http://127.0.0.1:18502`
